### PR TITLE
General updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 
 COPY ./*.csproj /app/
@@ -7,7 +7,7 @@ RUN dotnet restore
 COPY ./*.cs* /app/
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
+FROM mcr.microsoft.com/dotnet/runtime:8.0 AS runtime
 WORKDIR /app
 VOLUME [ "/app/sqlite" ]
 USER 1000

--- a/Generator.cs
+++ b/Generator.cs
@@ -74,6 +74,9 @@ namespace osu.Server.OnlineDbGenerator
         /// <param name="sqlite"></param>
         private void createSchema(SqliteConnection sqlite)
         {
+            sqlite.Execute("CREATE TABLE `schema_version` (`number` smallint unsigned NOT NULL)");
+            sqlite.Execute("INSERT INTO `schema_version` (`number`) VALUES (2)");
+
             sqlite.Execute(@"CREATE TABLE `osu_beatmapsets` (
                                   `beatmapset_id` mediumint unsigned NOT NULL,
                                   `submit_date` timestamp NOT NULL DEFAULT NULL,

--- a/osu-onlinedb-generator.csproj
+++ b/osu-onlinedb-generator.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.37" />
-    <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Microsoft.Data.SQLite" Version="6.0.8" />
-    <PackageReference Include="MySqlConnector" Version="2.1.11" />
-    <PackageReference Include="sharpcompress" Version="0.32.2" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.402" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="8.0.8" />
+    <PackageReference Include="MySqlConnector" Version="2.3.7" />
+    <PackageReference Include="sharpcompress" Version="0.37.2" />
   </ItemGroup>
 
 </Project>

--- a/osu-onlinedb-generator.csproj
+++ b/osu-onlinedb-generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>osu.Server.OnlineDbGenerator</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
- .NET version bumped to 8.0.
- Dependencies updated to latest.
- Added an explicit schema versioning table so that client can distinguish which version of the db schema it's dealing with. It's not strictly necessary (I could use `osu_beatmapsets` presence for this), but I figure if this file ever gets its schema changed again, this is probably better than playing games with ad-hoc indicators.

Note that apparently the currently-running production instance of this is 100% no further than https://github.com/ppy/osu-onlinedb-generator/commit/1d8899002a250deac663c747db4eca9263aa44ee, because I downloaded the generated db file today and it doesn't contain changes from https://github.com/ppy/osu-onlinedb-generator/commit/da5a35b419c83ee681e97b2132c5f57cc1d32fc9 or https://github.com/ppy/osu-onlinedb-generator/commit/512e47e50d69800aecd1f4ed6359180d89ba8f17, which I intend to use client-side to resolve https://github.com/ppy/osu/issues/22416.

More notes on client compatibility in the incoming client-side pull.